### PR TITLE
Include emitterChain in VAA data

### DIFF
--- a/src/api/vaas.ts
+++ b/src/api/vaas.ts
@@ -31,7 +31,9 @@ export const vaasHandler = async (req: Request, res: Response) => {
       );
 
       if (result !== undefined) {
-        res.status(200).json({ data: [{ vaa: result }] });
+        res.status(200).json({
+            data: [{ emitterChain: chainConfig.wormholeChainId, vaa: result }]
+        });
         return;
       }
     } catch (error) {

--- a/src/api/vaas.ts
+++ b/src/api/vaas.ts
@@ -32,7 +32,7 @@ export const vaasHandler = async (req: Request, res: Response) => {
 
       if (result !== undefined) {
         res.status(200).json({
-            data: [{ emitterChain: chainConfig.wormholeChainId, vaa: result }]
+          data: [{ emitterChain: chainConfig.wormholeChainId, vaa: result }],
         });
         return;
       }


### PR DESCRIPTION
In our system, we filter our VAAs produced for emitting chains that do not match what we have configured for a specific chain that we are sending from. We do this by relying on the `emitterChain` field present in VAA data in responses to `/api/v1/vaas`, so adding that field to the mock response returned by this service.